### PR TITLE
Add AST matching mini-library.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -152,6 +152,8 @@ disable=abstract-method,
         wrong-import-order,
         xrange-builtin,
         zip-builtin-not-iterating,
+        # Custom rules
+        use-dict-literal,
 
 
 [REPORTS]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #17
* #16
* __->__ #14
* #13
* #12

Add an `AST` wrapper class with a method `select_nodes(selector)` method for
returning all descendent AST nodes that match some predicate.

Add AST node predicates:
- `NodePredicate`: base class.
- `All`: intersection combinator of multiple `NodePredicate`s.
- `HasType(type)`: matches nodes with a given type.
- `HasLocationInfo`: matches nodes that have line number information.
- `OverlapsWithLineNumber(type)`: matches nodes that overlap with a line number.
- `IsProbeStatement`: matches nodes that are probe statements.
  - Currently matches all `triangulate_probe` function calls, which are
    generated via `instrumentation_utils.make_probe_call`.

These will replace previous AST utilities for extracting `Assert` statements,
which are less robust.