### PR TITLE
Use rich instead of termcolor for styled printing.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,8 @@ keywords = []
 dependencies = [
     "absl-py",
     "numpy",
+    "rich",
     "python-magic",
-    "termcolor",
 ]
 
 # `version` is automatically set by flit to use `triangulate.__version__`

--- a/triangulate/instrumentation_utils.py
+++ b/triangulate/instrumentation_utils.py
@@ -26,7 +26,7 @@ from typing import Any
 
 from triangulate import logging_utils
 
-print_color = logging_utils.print_color
+CONSOLE = logging_utils.CONSOLE
 
 # A unique name for the probing function.
 PROBE_FUNCTION_NAME = "triangulate_probe"
@@ -49,9 +49,8 @@ def probe(variable_names: Sequence[str], locals_dict: Mapping[str, Any]):
     full_probe_str.write("\n")
   if not full_probe_str.getvalue():
     return
-  print_color(
-      prompt=f"Probing: {caller.filename}:{caller.lineno}",
-      color="blue",
+  CONSOLE.print(
+      f"Probing: {caller.filename}:{caller.lineno}", style="bold blue"
   )
   print(full_probe_str.getvalue(), end="")
 
@@ -77,7 +76,7 @@ def run_with_instrumentation(
         runpy.run_path(f.name, init_globals=exec_globals, run_name="__main__")
     except Exception as e:  # pylint:disable=broad-except
       # Print exception from the executed program.
-      print_color("Exception raised:", color="yellow", bold=False)
+      CONSOLE.print("Exception raised:", style="yellow")
       traceback.print_exception(e.__context__ or e)
     finally:
       sys.argv = old_argv

--- a/triangulate/logging_utils.py
+++ b/triangulate/logging_utils.py
@@ -14,30 +14,18 @@
 
 """Printing and logging utilities."""
 
-import shutil
-import termcolor
+from typing import Any
+
+from rich.console import Console
+from rich.panel import Panel
 
 
-def print_color(
-    prompt: str,
-    message: str = "",
-    *,
-    color: int | str | None = None,
-    bold: bool = True,
-):
-  """Prints a prompt with optional message and formatting options."""
-  attrs = []
-  if bold:
-    attrs.append("bold")
-  if message != "":
-    prompt = f"{prompt}: "
-  prompt_colored = termcolor.colored(prompt, color=color, attrs=attrs)
-  if message:
-    print(f"{prompt_colored}{message}")
-  else:
-    print(prompt_colored)
+CONSOLE = Console()
 
 
-def print_horizontal_line():
-  terminal_size = shutil.get_terminal_size()
-  print("\u2500" * terminal_size.columns)
+def print_panel(renderable: Any, title: str = ""):
+  CONSOLE.print(Panel(renderable, title=title))
+
+
+def print_horizontal_line(title: str = ""):
+  CONSOLE.rule(title=title)

--- a/triangulate/sampling_utils.py
+++ b/triangulate/sampling_utils.py
@@ -57,7 +57,7 @@ def sample_wo_replacement_uniform(
   """
   if num_samples > len(support):
     raise ValueError(
-        "When sampling without replacement, the number of samples"
-        " cannot exceed the cardinality of the set."
+        "When sampling without replacement, the number of samples "
+        "cannot exceed the cardinality of the set."
     )
   return rng.choice(support, size=num_samples, replace=False)


### PR DESCRIPTION
[`rich`](https://github.com/Textualize/rich) has many more features than termcolor:
- Printing "rules" (horizontal lines) with an optional title.
- Printing panels.
- Printing source code with line numbers: no need for custom utility.

rich also happens to be better supported within Google.

Demo: https://asciinema.org/a/jp1p5fYNrHKH1mljGPQhrXWLs

[![asciicast](https://asciinema.org/a/jp1p5fYNrHKH1mljGPQhrXWLs.svg)](https://asciinema.org/a/jp1p5fYNrHKH1mljGPQhrXWLs)