### PR TITLE
Move main.py entry point function into core.py.

### DIFF
--- a/triangulate/testdata/quoter.py
+++ b/triangulate/testdata/quoter.py
@@ -16,7 +16,6 @@
 
 import argparse
 import random
-import sys
 
 
 # Define a dictionary of quotes and their attributions


### PR DESCRIPTION
Split the `main` function in main.py into separate functions in core.py:
- `def run(subject, subject_argv, ...)`
  - Executes the subject program with arguments. If an exception is thrown, the exception location is used as the bug location.
- `def run_from_exception(subject, subject_argv, exc_info, ...)`
  - Uses exception information (`exc_info`) to determine the bug location.
- `def run_with_bug_lineno(subject, subject_argv, bug_lineno, ...)`
  - Takes an explicit initial bug location.

Add a bug localization `ResultOrError` type: either a concrete `Result` or a `BugLocalizationException`.

Make the `run*` functions return `ResultOrError`.

Add tests for the `run*` entry point functions. This effectively tests main.py.

---

No functional changes.