### PR TITLE
Assorted cleanup.

### DIFF
--- a/triangulate/agents.py
+++ b/triangulate/agents.py
@@ -137,7 +137,7 @@ class RandomProbing(ProbingAgent):
     # Make probe statement, for inspecting the values of all variable in the
     # illegal state expression at a given line number.
     probe_variables = sorted(
-        n.node.id for n in state.get_illegal_state_expression_identifiers()
+        n.node.id for n in state.illegal_state_expression_identifiers()
     )
     probe_statement = instrumentation_utils.make_probe_call(probe_variables)
     return tuple((Probe(offset, probe_statement)) for offset in line_numbers)
@@ -257,7 +257,7 @@ class SearchAgent(Agent, Generic[SearchStrategy]):
 
 def make_search_agent_factory(
     strategy_type: type[SearchStrategy],
-) -> Callable[[], Agent]:
+) -> Callable[[], SearchAgent]:
   """Returns a factory function that creates a search agent with fresh state."""
   return lambda: SearchAgent(strategy_type=strategy_type)
 

--- a/triangulate/environment.py
+++ b/triangulate/environment.py
@@ -39,7 +39,6 @@ ProgramGraphNode = program_graph.ProgramGraphNode
 
 CONSOLE = logging_utils.CONSOLE
 rprint = CONSOLE.print
-print_horizontal_line = logging_utils.print_horizontal_line
 print_panel = logging_utils.print_panel
 
 
@@ -124,10 +123,10 @@ class State:
 
     if self.candidate_variables_to_inspect is None:
       self.candidate_variables_to_inspect = OrderedSet(
-          self.get_illegal_state_expression_identifiers()
+          self.illegal_state_expression_identifiers()
       )
 
-  def get_illegal_state_expression_identifiers(
+  def illegal_state_expression_identifiers(
       self,
   ) -> OrderedSet[ProgramGraphNode]:
     """Returns all variable identifiers in the illegal state expression."""

--- a/triangulate/llm.py
+++ b/triangulate/llm.py
@@ -82,7 +82,7 @@ def list_palm_models():
     rprint(model)
 
 
-@retry.Retry(timeout=TIMEOUT_SECONDS)
+@retry.Retry(deadline=TIMEOUT_SECONDS)
 def generate_palm_text(
     prompt: str,
     model: ModelType | str | None = None,

--- a/triangulate/logging_utils.py
+++ b/triangulate/logging_utils.py
@@ -30,7 +30,3 @@ rprint = CONSOLE.print
 
 def print_panel(renderable: Any, title: str = ""):
   CONSOLE.print(Panel(renderable, title=title))
-
-
-def print_horizontal_line(title: str = ""):
-  CONSOLE.rule(title=title)


### PR DESCRIPTION
- Use `Retry(deadline=...)` instead of `Retry(timeout=...)`.
  - Support older versions of [google.api_core](https://github.com/googleapis/python-api-core) (2.10.2) before `timeout` was added.
- Remove unused function `print_horizontal_line`.
- Minor naming and type annotation polish.

No functional changes.